### PR TITLE
Only add quality-acceleration modules to machine.allowed_modules if there are already values set.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.1.4
+Date: 2025-01-06
+  Bugfixes:
+    - No longer overriding ability to place modules in machines with the Quality Acceleration modules.
+---------------------------------------------------------------------------------------------------
 Version: 0.1.3
 Date: 2025-01-06
   Features:

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -17,13 +17,24 @@ for _, machineType in pairs(machineTypes) do
 				};
 			end
 		end
-		table.insert(machine.allowed_effects, "quality");
-		machine.effect_receiver.uses_beacon_effects = true;
+
+		function in_array(array, value)
+			for _, v in pairs(array) do
+				if v == value then
+					return true;
+				end
+			end
+			return false;
+		end
+
+		if not in_array(machine.allowed_effects, "quality") then
+			table.insert(machine.allowed_effects, "quality");
+		end
 
 		-- Quality Acceleration modules
-		if machine.allowed_module_categories == nil then
+		if machine.allowed_module_categories ~= nil then
 			machine.allowed_module_categories = {};
+			table.insert(machine.allowed_module_categories, "quality-acceleration");
 		end
-		table.insert(machine.allowed_module_categories, "quality-acceleration");
 	end
 end

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "grogs-quality-hell",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"title": "Grog's Quality Hell",
 	"description": "Love Quality?  Can't get enough of it?  Want more, from the start?  This mod is for you!  All machines (furnaces, drills, crafting) start out will a small amount of quality bonus, and it increases over time as the machine is used.  Works with modded machines.  Settings to tweak to your liking.  Tips+Tricks included.  Safe to add/remove to/from existing games.",
 	"author": "grogathar",


### PR DESCRIPTION
resolves #4 